### PR TITLE
Add basic unit tests for carousel

### DIFF
--- a/projects/carousel/src/lib/carousel-scroll.directive.spec.ts
+++ b/projects/carousel/src/lib/carousel-scroll.directive.spec.ts
@@ -1,0 +1,33 @@
+import { Component } from '@angular/core';
+import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { CarouselScrollDirective } from './carousel-scroll.directive';
+
+@Component({
+  template: `<div appCarouselScroll></div>`
+})
+class HostComponent {}
+
+describe('CarouselScrollDirective', () => {
+  let fixture: ComponentFixture<HostComponent>;
+  let directive: CarouselScrollDirective;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [HostComponent, CarouselScrollDirective]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(HostComponent);
+    directive = fixture.debugElement.query(By.directive(CarouselScrollDirective)).injector.get(CarouselScrollDirective);
+    fixture.detectChanges();
+  });
+
+  it('should emit wheel direction', fakeAsync(() => {
+    const values: number[] = [];
+    directive.appCarouselScroll.subscribe(v => values.push(v));
+    const el = fixture.debugElement.query(By.directive(CarouselScrollDirective)).nativeElement;
+    el.dispatchEvent(new WheelEvent('wheel', { deltaX: 30 }));
+    tick(0);
+    expect(values).toEqual([1]);
+  }));
+});

--- a/projects/carousel/src/lib/carousel/carousel.component.spec.ts
+++ b/projects/carousel/src/lib/carousel/carousel.component.spec.ts
@@ -1,0 +1,60 @@
+import { Component } from '@angular/core';
+import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { CarouselComponent } from './carousel.component';
+import { CarouselItemDirective } from './carousel-item.directive';
+import { CarouselDirective } from './carousel.directive';
+import { CarouselAutoScrollDirective } from '../carousel-auto-scroll.directive';
+import { CarouselScrollDirective } from '../carousel-scroll.directive';
+
+@Component({
+  template: `
+    <app-carousel [display]="1" [index]="0">
+      <ng-template appCarouselItem>Item 1</ng-template>
+      <ng-template appCarouselItem>Item 2</ng-template>
+      <ng-template appCarouselItem>Item 3</ng-template>
+    </app-carousel>
+  `
+})
+class HostComponent { }
+
+describe('CarouselComponent', () => {
+  let fixture: ComponentFixture<HostComponent>;
+  let component: CarouselComponent;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [
+        HostComponent,
+        CarouselComponent,
+        CarouselDirective,
+        CarouselItemDirective,
+        CarouselScrollDirective,
+        CarouselAutoScrollDirective,
+      ]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(HostComponent);
+    component = fixture.debugElement.query(By.directive(CarouselComponent)).componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should render all carousel items', () => {
+    const items = fixture.nativeElement.querySelectorAll('.item');
+    expect(items.length).toBe(3);
+  });
+
+  it('should advance to next and previous item', () => {
+    component.next();
+    expect(component.index).toBe(1);
+    component.prev();
+    expect(component.index).toBe(0);
+  });
+
+  it('should wrap around when reaching the end', () => {
+    component.index = 2;
+    fixture.detectChanges();
+    component.next();
+    expect(component.index).toBe(0);
+  });
+});

--- a/projects/carousel/src/lib/carousel/carousel.directive.spec.ts
+++ b/projects/carousel/src/lib/carousel/carousel.directive.spec.ts
@@ -1,0 +1,21 @@
+import { ElementRef } from '@angular/core';
+import { fakeAsync, tick } from '@angular/core/testing';
+import { CarouselDirective } from './carousel.directive';
+
+describe('CarouselDirective', () => {
+  it('emits periodically when enabled', fakeAsync(() => {
+    const div = document.createElement('div');
+    const directive = new CarouselDirective(new ElementRef(div));
+    const values: number[] = [];
+    directive.duration = 50;
+    directive.subscribe(() => values.push(values.length));
+    div.dispatchEvent(new Event('mouseleave'));
+    tick(120);
+    expect(values.length).toBeGreaterThan(0);
+
+    div.dispatchEvent(new Event('mouseenter'));
+    const prev = values.length;
+    tick(60);
+    expect(values.length).toBe(prev);
+  }));
+});


### PR DESCRIPTION
## Summary
- add unit tests for carousel component and directives

## Testing
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_b_684aabd3cbcc83338d41158de84cb9b5