### PR TITLE
Add survey-builder library project

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -34,6 +34,37 @@
         }
       }
     },
+    "survey-builder": {
+      "projectType": "library",
+      "root": "projects/survey-builder",
+      "sourceRoot": "projects/survey-builder/src",
+      "prefix": "avs",
+      "architect": {
+        "build": {
+          "builder": "@angular-devkit/build-angular:ng-packagr",
+          "options": {
+            "project": "projects/survey-builder/ng-package.json"
+          },
+          "configurations": {
+            "production": {
+              "tsConfig": "projects/survey-builder/tsconfig.lib.prod.json"
+            },
+            "development": {
+              "tsConfig": "projects/survey-builder/tsconfig.lib.json"
+            }
+          },
+          "defaultConfiguration": "production"
+        },
+        "test": {
+          "builder": "@angular-devkit/build-angular:karma",
+          "options": {
+            "main": "projects/survey-builder/src/test.ts",
+            "tsConfig": "projects/survey-builder/tsconfig.spec.json",
+            "karmaConfig": "projects/survey-builder/karma.conf.js"
+          }
+        }
+      }
+    },
     "example": {
       "projectType": "application",
       "schematics": {

--- a/projects/survey-builder/README.md
+++ b/projects/survey-builder/README.md
@@ -1,0 +1,3 @@
+# Survey Builder
+
+This library was generated manually for testing purposes.

--- a/projects/survey-builder/karma.conf.js
+++ b/projects/survey-builder/karma.conf.js
@@ -1,0 +1,37 @@
+// Karma configuration file for survey-builder
+module.exports = function (config) {
+  config.set({
+    basePath: '',
+    frameworks: ['jasmine', '@angular-devkit/build-angular'],
+    plugins: [
+      require('karma-jasmine'),
+      require('karma-chrome-launcher'),
+      require('karma-jasmine-html-reporter'),
+      require('karma-coverage'),
+      require('@angular-devkit/build-angular/plugins/karma')
+    ],
+    client: {
+      jasmine: {},
+      clearContext: false
+    },
+    jasmineHtmlReporter: {
+      suppressAll: true
+    },
+    coverageReporter: {
+      dir: require('path').join(__dirname, '../../coverage/survey-builder'),
+      subdir: '.',
+      reporters: [
+        { type: 'html' },
+        { type: 'text-summary' }
+      ]
+    },
+    reporters: ['progress', 'kjhtml'],
+    port: 9876,
+    colors: true,
+    logLevel: config.LOG_INFO,
+    autoWatch: true,
+    browsers: ['Chrome'],
+    singleRun: false,
+    restartOnFileChange: true
+  });
+};

--- a/projects/survey-builder/ng-package.json
+++ b/projects/survey-builder/ng-package.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "../../node_modules/ng-packagr/ng-package.schema.json",
+  "dest": "../../dist/survey-builder",
+  "lib": {
+    "entryFile": "src/public-api.ts"
+  }
+}

--- a/projects/survey-builder/package.json
+++ b/projects/survey-builder/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "@avs2001/survey-builder",
+  "version": "0.0.0",
+  "peerDependencies": {
+    "@angular/common": "^15.0.0",
+    "@angular/core": "^15.0.0"
+  },
+  "dependencies": {
+    "tslib": "^2.3.0"
+  }
+}

--- a/projects/survey-builder/src/lib/survey-builder.component.ts
+++ b/projects/survey-builder/src/lib/survey-builder.component.ts
@@ -1,0 +1,8 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'lib-survey-builder',
+  template: `survey-builder works!`,
+  styles: []
+})
+export class SurveyBuilderComponent {}

--- a/projects/survey-builder/src/lib/survey-builder.module.ts
+++ b/projects/survey-builder/src/lib/survey-builder.module.ts
@@ -1,0 +1,9 @@
+import { NgModule } from '@angular/core';
+import { SurveyBuilderComponent } from './survey-builder.component';
+
+@NgModule({
+  declarations: [SurveyBuilderComponent],
+  imports: [],
+  exports: [SurveyBuilderComponent]
+})
+export class SurveyBuilderModule {}

--- a/projects/survey-builder/src/lib/survey-builder.service.ts
+++ b/projects/survey-builder/src/lib/survey-builder.service.ts
@@ -1,0 +1,8 @@
+import { Injectable } from '@angular/core';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class SurveyBuilderService {
+  constructor() { }
+}

--- a/projects/survey-builder/src/public-api.ts
+++ b/projects/survey-builder/src/public-api.ts
@@ -1,0 +1,7 @@
+/*
+ * Public API Surface of survey-builder
+ */
+
+export * from './lib/survey-builder.service';
+export * from './lib/survey-builder.component';
+export * from './lib/survey-builder.module';

--- a/projects/survey-builder/src/test.ts
+++ b/projects/survey-builder/src/test.ts
@@ -1,0 +1,12 @@
+import 'zone.js';
+import 'zone.js/testing';
+import { getTestBed } from '@angular/core/testing';
+import {
+  BrowserDynamicTestingModule,
+  platformBrowserDynamicTesting
+} from '@angular/platform-browser-dynamic/testing';
+
+getTestBed().initTestEnvironment(
+  BrowserDynamicTestingModule,
+  platformBrowserDynamicTesting(),
+);

--- a/projects/survey-builder/tsconfig.lib.json
+++ b/projects/survey-builder/tsconfig.lib.json
@@ -1,0 +1,15 @@
+/* To learn more about this file see: https://angular.io/config/tsconfig. */
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../out-tsc/lib",
+    "declaration": true,
+    "declarationMap": true,
+    "inlineSources": true,
+    "types": []
+  },
+  "exclude": [
+    "src/test.ts",
+    "**/*.spec.ts"
+  ]
+}

--- a/projects/survey-builder/tsconfig.lib.prod.json
+++ b/projects/survey-builder/tsconfig.lib.prod.json
@@ -1,0 +1,10 @@
+/* To learn more about this file see: https://angular.io/config/tsconfig. */
+{
+  "extends": "./tsconfig.lib.json",
+  "compilerOptions": {
+    "declarationMap": false
+  },
+  "angularCompilerOptions": {
+    "compilationMode": "partial"
+  }
+}

--- a/projects/survey-builder/tsconfig.spec.json
+++ b/projects/survey-builder/tsconfig.spec.json
@@ -1,0 +1,17 @@
+/* To learn more about this file see: https://angular.io/config/tsconfig. */
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../out-tsc/spec",
+    "types": [
+      "jasmine"
+    ]
+  },
+  "files": [
+    "src/test.ts"
+  ],
+  "include": [
+    "**/*.spec.ts",
+    "**/*.d.ts"
+  ]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,9 @@
     "paths": {
       "carousel": [
         "dist/carousel"
+      ],
+      "survey-builder": [
+        "dist/survey-builder"
       ]
     },
     "outDir": "./dist/out-tsc",


### PR DESCRIPTION
## Summary
- introduce `survey-builder` as an Angular library within the workspace
- add `survey-builder` configuration to `angular.json` and path mapping in `tsconfig.json`

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_b_684ab0c024f4833382afdf9a8dfe6486