### PR TITLE
Add basic survey builder implementation

### DIFF
--- a/projects/survey-builder/README.md
+++ b/projects/survey-builder/README.md
@@ -1,3 +1,25 @@
 # Survey Builder
 
-This library was generated manually for testing purposes.
+This library provides a basic survey builder for Angular applications. It allows administrators to add questions and preview the resulting form in real time.
+
+## Features
+
+- Add questions with various types (text, long text, radio, checkbox, dropdown, date, file, video)
+- Mark questions as required or optional
+- Add options for radio, checkbox and dropdown questions
+- Reorder questions using move up/down controls
+- Live preview of the generated form
+- Draft persistence using `localStorage`
+
+The component is exported from `SurveyBuilderModule` and can be used as follows:
+
+```ts
+import { SurveyBuilderModule } from '@avs2001/survey-builder';
+```
+
+In your template:
+```html
+<lib-survey-builder></lib-survey-builder>
+```
+
+This is a minimal implementation aimed at demonstrating the survey builder interface. It can be extended to support additional features such as drag-and-drop, advanced validation rules and role-based access.

--- a/projects/survey-builder/src/lib/survey-builder.component.html
+++ b/projects/survey-builder/src/lib/survey-builder.component.html
@@ -1,0 +1,71 @@
+<div class="survey-builder">
+  <div class="question-editor">
+    <h3>Questions</h3>
+    <div *ngFor="let q of questions; index as i" class="question-item">
+      <span>{{ q.label }} ({{ q.type }})</span>
+      <button type="button" (click)="moveUp(i)" [disabled]="i === 0">↑</button>
+      <button type="button" (click)="moveDown(i)" [disabled]="i === questions.length - 1">↓</button>
+      <button type="button" (click)="removeQuestion(i)">✕</button>
+    </div>
+    <form [formGroup]="newQuestionForm" (ngSubmit)="addQuestion()" class="new-question">
+      <label>
+        Label
+        <input formControlName="label" />
+      </label>
+      <label>
+        Type
+        <select formControlName="type">
+          <option value="text">Text</option>
+          <option value="textarea">Long Text</option>
+          <option value="radio">Radio</option>
+          <option value="checkbox">Checkbox</option>
+          <option value="dropdown">Dropdown</option>
+          <option value="date">Date</option>
+          <option value="file">File</option>
+          <option value="video">Video</option>
+        </select>
+      </label>
+      <label>
+        Required
+        <input type="checkbox" formControlName="required" />
+      </label>
+      <div formArrayName="options" *ngIf="['radio','checkbox','dropdown'].includes(newQuestionForm.value.type)">
+        <div *ngFor="let opt of options.controls; index as j">
+          <input [formControlName]="j" />
+          <button type="button" (click)="removeOption(j)">Remove</button>
+        </div>
+        <button type="button" (click)="addOption()">Add option</button>
+      </div>
+      <button type="submit" [disabled]="newQuestionForm.invalid">Add Question</button>
+    </form>
+  </div>
+
+  <div class="preview">
+    <h3>Preview</h3>
+    <form [formGroup]="previewForm">
+      <div *ngFor="let q of questions" class="preview-item">
+        <label [attr.for]="'q' + q.id">{{ q.label }}</label>
+        <ng-container [ngSwitch]="q.type">
+          <input *ngSwitchCase="'text'" [formControlName]="'q' + q.id" type="text" [required]="q.required" />
+          <textarea *ngSwitchCase="'textarea'" [formControlName]="'q' + q.id" [required]="q.required"></textarea>
+          <select *ngSwitchCase="'dropdown'" [formControlName]="'q' + q.id" [required]="q.required">
+            <option *ngFor="let o of q.options" [value]="o">{{ o }}</option>
+          </select>
+          <div *ngSwitchCase="'radio'">
+            <label *ngFor="let o of q.options">
+              <input type="radio" [value]="o" [formControlName]="'q' + q.id" [required]="q.required" /> {{ o }}
+            </label>
+          </div>
+          <div *ngSwitchCase="'checkbox'">
+            <label *ngFor="let o of q.options; index as cIndex">
+              <input type="checkbox" [formControlName]="'q' + q.id" /> {{ o }}
+            </label>
+          </div>
+          <input *ngSwitchCase="'date'" type="date" [formControlName]="'q' + q.id" [required]="q.required" />
+          <input *ngSwitchCase="'file'" type="file" [formControlName]="'q' + q.id" [required]="q.required" />
+          <input *ngSwitchCase="'video'" type="url" [formControlName]="'q' + q.id" [required]="q.required" placeholder="Video URL" />
+        </ng-container>
+      </div>
+    </form>
+  </div>
+</div>

--- a/projects/survey-builder/src/lib/survey-builder.component.scss
+++ b/projects/survey-builder/src/lib/survey-builder.component.scss
@@ -1,0 +1,27 @@
+.survey-builder {
+  display: flex;
+  gap: 2rem;
+}
+
+.question-editor,
+.preview {
+  flex: 1;
+}
+
+.question-item {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  margin-bottom: 0.25rem;
+}
+
+.new-question {
+  margin-top: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.preview-item {
+  margin-bottom: 0.5rem;
+}

--- a/projects/survey-builder/src/lib/survey-builder.component.ts
+++ b/projects/survey-builder/src/lib/survey-builder.component.ts
@@ -1,8 +1,115 @@
 import { Component } from '@angular/core';
+import { FormArray, FormBuilder, FormGroup, Validators } from '@angular/forms';
+import { SurveyBuilderService } from './survey-builder.service';
+
+export type QuestionType =
+  | 'text'
+  | 'textarea'
+  | 'radio'
+  | 'checkbox'
+  | 'dropdown'
+  | 'date'
+  | 'file'
+  | 'video';
+
+export interface SurveyQuestion {
+  id: number;
+  label: string;
+  type: QuestionType;
+  required: boolean;
+  options?: string[]; // used for radio/checkbox/dropdown
+}
 
 @Component({
   selector: 'lib-survey-builder',
-  template: `survey-builder works!`,
-  styles: []
+  templateUrl: './survey-builder.component.html',
+  styleUrls: ['./survey-builder.component.scss'],
 })
-export class SurveyBuilderComponent {}
+export class SurveyBuilderComponent {
+  questions: SurveyQuestion[] = [];
+  nextId = 1;
+
+  newQuestionForm: FormGroup;
+  previewForm: FormGroup;
+
+  constructor(private fb: FormBuilder, private service: SurveyBuilderService) {
+    this.newQuestionForm = this.fb.group({
+      label: ['', Validators.required],
+      type: ['text', Validators.required],
+      required: [false],
+      options: this.fb.array([]),
+    });
+    this.previewForm = this.fb.group({});
+    this.questions = this.service.loadDraft();
+    if (this.questions.length) {
+      this.nextId = Math.max(...this.questions.map(q => q.id)) + 1;
+      this.buildPreviewForm();
+    }
+  }
+
+  get options(): FormArray {
+    return this.newQuestionForm.get('options') as FormArray;
+  }
+
+  addOption(): void {
+    this.options.push(this.fb.control(''));
+  }
+
+  removeOption(index: number): void {
+    this.options.removeAt(index);
+  }
+
+  addQuestion(): void {
+    if (this.newQuestionForm.invalid) {
+      return;
+    }
+    const question: SurveyQuestion = {
+      id: this.nextId++,
+      label: this.newQuestionForm.value.label,
+      type: this.newQuestionForm.value.type,
+      required: this.newQuestionForm.value.required,
+      options: this.newQuestionForm.value.options.filter((o: string) => o),
+    };
+    this.questions.push(question);
+    this.newQuestionForm.reset({ type: 'text', required: false });
+    this.options.clear();
+    this.buildPreviewForm();
+    this.service.saveDraft(this.questions);
+  }
+
+  removeQuestion(index: number): void {
+    this.questions.splice(index, 1);
+    this.buildPreviewForm();
+    this.service.saveDraft(this.questions);
+  }
+
+  moveUp(index: number): void {
+    if (index > 0) {
+      const tmp = this.questions[index - 1];
+      this.questions[index - 1] = this.questions[index];
+      this.questions[index] = tmp;
+      this.service.saveDraft(this.questions);
+    }
+  }
+
+  moveDown(index: number): void {
+    if (index < this.questions.length - 1) {
+      const tmp = this.questions[index + 1];
+      this.questions[index + 1] = this.questions[index];
+      this.questions[index] = tmp;
+      this.service.saveDraft(this.questions);
+    }
+  }
+
+  private buildPreviewForm(): void {
+    const group: { [key: string]: any } = {};
+    this.questions.forEach(q => {
+      const validators = q.required ? [Validators.required] : [];
+      group['q' + q.id] = [''];
+      if (validators.length) {
+        group['q' + q.id].push(validators);
+      }
+    });
+    this.previewForm = this.fb.group(group);
+  }
+}

--- a/projects/survey-builder/src/lib/survey-builder.module.ts
+++ b/projects/survey-builder/src/lib/survey-builder.module.ts
@@ -1,9 +1,11 @@
 import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ReactiveFormsModule } from '@angular/forms';
 import { SurveyBuilderComponent } from './survey-builder.component';
 
 @NgModule({
   declarations: [SurveyBuilderComponent],
-  imports: [],
-  exports: [SurveyBuilderComponent]
+  imports: [CommonModule, ReactiveFormsModule],
+  exports: [SurveyBuilderComponent],
 })
 export class SurveyBuilderModule {}

--- a/projects/survey-builder/src/lib/survey-builder.service.ts
+++ b/projects/survey-builder/src/lib/survey-builder.service.ts
@@ -1,8 +1,18 @@
 import { Injectable } from '@angular/core';
+import { SurveyQuestion } from './survey-builder.component';
 
 @Injectable({
-  providedIn: 'root'
+  providedIn: 'root',
 })
 export class SurveyBuilderService {
-  constructor() { }
+  private STORAGE_KEY = 'survey-builder-draft';
+
+  saveDraft(questions: SurveyQuestion[]): void {
+    localStorage.setItem(this.STORAGE_KEY, JSON.stringify(questions));
+  }
+
+  loadDraft(): SurveyQuestion[] {
+    const data = localStorage.getItem(this.STORAGE_KEY);
+    return data ? (JSON.parse(data) as SurveyQuestion[]) : [];
+  }
 }


### PR DESCRIPTION
## Summary
- implement a simple survey builder component
- add styles and HTML template
- persist draft questions with a service
- update module to import Forms modules
- document how to use the survey builder

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_b_684ab25ce9208333866a2bbf47e5bf0d