### PR TITLE
Add survey builder demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,15 @@ ng build survey-builder
 
 Include `<lib-survey-builder>` in your standalone Angular components to allow administrators to create surveys. The builder supports editing, drag-and-drop ordering, duplication, advanced validation and import/export of survey definitions.
 
+## Example application
+
+The `projects/example` Angular app demonstrates the carousel components and also
+contains a basic `<lib-survey-builder>` instance. Run it with:
+
+```bash
+ng serve example
+```
+
 ## Running end-to-end tests
 
 Run `ng e2e` to execute the end-to-end tests via a platform of your choice. To use this command, you need to first add a package that implements end-to-end testing capabilities.

--- a/projects/example/src/app/app.component.html
+++ b/projects/example/src/app/app.component.html
@@ -15,3 +15,6 @@
 </app-carousel>
 <button (click)="carousel.prev()">Prev</button>
 <button (click)="carousel.next()">Next</button>
+
+<h2>Survey Builder Demo</h2>
+<lib-survey-builder></lib-survey-builder>

--- a/projects/example/src/app/app.component.ts
+++ b/projects/example/src/app/app.component.ts
@@ -5,6 +5,7 @@ import {CarouselItemDirective} from 'carousel';
 import {CarouselScrollDirective} from 'carousel';
 import {CarouselAutoScrollDirective} from 'carousel';
 import {CarouselDirective} from 'carousel';
+import { SurveyBuilderComponent } from 'survey-builder';
 
 @Component({
   selector: 'app-root',
@@ -18,6 +19,7 @@ import {CarouselDirective} from 'carousel';
     CarouselScrollDirective,
     CarouselAutoScrollDirective,
     CarouselDirective,
+    SurveyBuilderComponent,
   ]
 })
 export class AppComponent {


### PR DESCRIPTION
## Summary
- add `SurveyBuilderComponent` to the example app
- demo `<lib-survey-builder>` in `app.component.html`
- document the example application in README

## Testing
- `npx ng test --watch=false` *(fails: ng not found due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_b_684abb2d44948333b39fa07fb11404d3